### PR TITLE
Add translations for multiple Spanish dialects

### DIFF
--- a/src/main/resources/data/biometech/lang/es_ar.json
+++ b/src/main/resources/data/biometech/lang/es_ar.json
@@ -1,0 +1,19 @@
+{
+  "block.biometech.biome_converter": "Convertidor de Bioma",
+  "item.biometech.biome_essence": "Esencia de bioma (%s)",
+  "gui.biometech.close": "Cerrar",
+  "gui.biometech.pages": "%s/%s",
+  "gui.biometech.fuel": "Combustible",
+  "gui.biometech.fuel.brackets": "[%s]",
+  "gui.biometech.button.activate": "Activar",
+  "gui.biometech.button.deactivate": "Desactivar",
+  "gui.biometech.no_biome": "Ningún Bioma Seleccionado!",
+  "gui.biometech.radius": "Radio: %s",
+  "gui.biometech.button.clear_biome": "Clic para quitar el bioma!",
+  "gamerule.biometech:fuel_per_change": "Cantidad de combustible para un solo cambio de bioma",
+  "gamerule.biometech:uses_per_essence": "Cantidad de usos de una sola Esencia de Bioma",
+  "gamerule.biometech:delay_between_changes": "Retraso (en ticks) entre cambios de bioma",
+  "gamerule.biometech:max_checks_per_tick": "Número máximo de chequeos de bioma por tick",
+  "gamerule.biometech:max_radius": "Radio máximo del Convertidor de Bioma",
+  "gamerule.biometech:wandering_traders_sell_essence": "Comerciantes Nómadas venden Esencia de Bioma"
+}

--- a/src/main/resources/data/biometech/lang/es_cl.json
+++ b/src/main/resources/data/biometech/lang/es_cl.json
@@ -1,0 +1,19 @@
+{
+  "block.biometech.biome_converter": "Convertidor de Bioma",
+  "item.biometech.biome_essence": "Esencia de bioma (%s)",
+  "gui.biometech.close": "Cerrar",
+  "gui.biometech.pages": "%s/%s",
+  "gui.biometech.fuel": "Combustible",
+  "gui.biometech.fuel.brackets": "[%s]",
+  "gui.biometech.button.activate": "Activar",
+  "gui.biometech.button.deactivate": "Desactivar",
+  "gui.biometech.no_biome": "Ningún Bioma Seleccionado!",
+  "gui.biometech.radius": "Radio: %s",
+  "gui.biometech.button.clear_biome": "Clic para quitar el bioma!",
+  "gamerule.biometech:fuel_per_change": "Cantidad de combustible para un solo cambio de bioma",
+  "gamerule.biometech:uses_per_essence": "Cantidad de usos de una sola Esencia de Bioma",
+  "gamerule.biometech:delay_between_changes": "Retraso (en ticks) entre cambios de bioma",
+  "gamerule.biometech:max_checks_per_tick": "Número máximo de chequeos de bioma por tick",
+  "gamerule.biometech:max_radius": "Radio máximo del Convertidor de Bioma",
+  "gamerule.biometech:wandering_traders_sell_essence": "Vendedores Ambulantes venden Esencia de Bioma"
+}

--- a/src/main/resources/data/biometech/lang/es_ec.json
+++ b/src/main/resources/data/biometech/lang/es_ec.json
@@ -1,0 +1,19 @@
+{
+  "block.biometech.biome_converter": "Convertidor de Bioma",
+  "item.biometech.biome_essence": "Esencia de bioma (%s)",
+  "gui.biometech.close": "Cerrar",
+  "gui.biometech.pages": "%s/%s",
+  "gui.biometech.fuel": "Combustible",
+  "gui.biometech.fuel.brackets": "[%s]",
+  "gui.biometech.button.activate": "Activar",
+  "gui.biometech.button.deactivate": "Desactivar",
+  "gui.biometech.no_biome": "Ningún Bioma Seleccionado!",
+  "gui.biometech.radius": "Radio: %s",
+  "gui.biometech.button.clear_biome": "Clic para quitar el bioma!",
+  "gamerule.biometech:fuel_per_change": "Cantidad de combustible para un solo cambio de bioma",
+  "gamerule.biometech:uses_per_essence": "Cantidad de usos de una sola Esencia de Bioma",
+  "gamerule.biometech:delay_between_changes": "Retraso (en ticks) entre cambios de bioma",
+  "gamerule.biometech:max_checks_per_tick": "Número máximo de chequeos de bioma por tick",
+  "gamerule.biometech:max_radius": "Radio máximo del Convertidor de Bioma",
+  "gamerule.biometech:wandering_traders_sell_essence": "Comerciantes Nómadas venden Esencia de Bioma"
+}

--- a/src/main/resources/data/biometech/lang/es_es.json
+++ b/src/main/resources/data/biometech/lang/es_es.json
@@ -1,0 +1,19 @@
+{
+  "block.biometech.biome_converter": "Convertidor de Bioma",
+  "item.biometech.biome_essence": "Esencia de bioma (%s)",
+  "gui.biometech.close": "Cerrar",
+  "gui.biometech.pages": "%s/%s",
+  "gui.biometech.fuel": "Combustible",
+  "gui.biometech.fuel.brackets": "[%s]",
+  "gui.biometech.button.activate": "Activar",
+  "gui.biometech.button.deactivate": "Desactivar",
+  "gui.biometech.no_biome": "Ningún Bioma Seleccionado!",
+  "gui.biometech.radius": "Radio: %s",
+  "gui.biometech.button.clear_biome": "Clic para quitar el bioma!",
+  "gamerule.biometech:fuel_per_change": "Cantidad de combustible para un solo cambio de bioma",
+  "gamerule.biometech:uses_per_essence": "Cantidad de usos de una sola Esencia de Bioma",
+  "gamerule.biometech:delay_between_changes": "Retraso (en ticks) entre cambios de bioma",
+  "gamerule.biometech:max_checks_per_tick": "Número máximo de chequeos de bioma por tick",
+  "gamerule.biometech:max_radius": "Radio máximo del Convertidor de Bioma",
+  "gamerule.biometech:wandering_traders_sell_essence": "Vendedores Ambulantes venden Esencia de Bioma"
+}

--- a/src/main/resources/data/biometech/lang/es_mx.json
+++ b/src/main/resources/data/biometech/lang/es_mx.json
@@ -1,0 +1,19 @@
+{
+  "block.biometech.biome_converter": "Convertidor de Bioma",
+  "item.biometech.biome_essence": "Esencia de bioma (%s)",
+  "gui.biometech.close": "Cerrar",
+  "gui.biometech.pages": "%s/%s",
+  "gui.biometech.fuel": "Combustible",
+  "gui.biometech.fuel.brackets": "[%s]",
+  "gui.biometech.button.activate": "Activar",
+  "gui.biometech.button.deactivate": "Desactivar",
+  "gui.biometech.no_biome": "Ningún Bioma Seleccionado!",
+  "gui.biometech.radius": "Radio: %s",
+  "gui.biometech.button.clear_biome": "Clic para quitar el bioma!",
+  "gamerule.biometech:fuel_per_change": "Cantidad de combustible para un solo cambio de bioma",
+  "gamerule.biometech:uses_per_essence": "Cantidad de usos de una sola Esencia de Bioma",
+  "gamerule.biometech:delay_between_changes": "Retraso (en ticks) entre cambios de bioma",
+  "gamerule.biometech:max_checks_per_tick": "Número máximo de chequeos de bioma por tick",
+  "gamerule.biometech:max_radius": "Radio máximo del Convertidor de Bioma",
+  "gamerule.biometech:wandering_traders_sell_essence": "Comerciantes Nómadas venden Esencia de Bioma"
+}

--- a/src/main/resources/data/biometech/lang/es_uy.json
+++ b/src/main/resources/data/biometech/lang/es_uy.json
@@ -1,0 +1,19 @@
+{
+  "block.biometech.biome_converter": "Convertidor de Bioma",
+  "item.biometech.biome_essence": "Esencia de bioma (%s)",
+  "gui.biometech.close": "Cerrar",
+  "gui.biometech.pages": "%s/%s",
+  "gui.biometech.fuel": "Combustible",
+  "gui.biometech.fuel.brackets": "[%s]",
+  "gui.biometech.button.activate": "Activar",
+  "gui.biometech.button.deactivate": "Desactivar",
+  "gui.biometech.no_biome": "Ningún Bioma Seleccionado!",
+  "gui.biometech.radius": "Radio: %s",
+  "gui.biometech.button.clear_biome": "Clic para quitar el bioma!",
+  "gamerule.biometech:fuel_per_change": "Cantidad de combustible para un solo cambio de bioma",
+  "gamerule.biometech:uses_per_essence": "Cantidad de usos de una sola Esencia de Bioma",
+  "gamerule.biometech:delay_between_changes": "Retraso (en ticks) entre cambios de bioma",
+  "gamerule.biometech:max_checks_per_tick": "Número máximo de chequeos de bioma por tick",
+  "gamerule.biometech:max_radius": "Radio máximo del Convertidor de Bioma",
+  "gamerule.biometech:wandering_traders_sell_essence": "Comerciantes Nómadas venden Esencia de Bioma"
+}

--- a/src/main/resources/data/biometech/lang/es_ve.json
+++ b/src/main/resources/data/biometech/lang/es_ve.json
@@ -1,0 +1,19 @@
+{
+  "block.biometech.biome_converter": "Convertidor de Bioma",
+  "item.biometech.biome_essence": "Esencia de bioma (%s)",
+  "gui.biometech.close": "Cerrar",
+  "gui.biometech.pages": "%s/%s",
+  "gui.biometech.fuel": "Combustible",
+  "gui.biometech.fuel.brackets": "[%s]",
+  "gui.biometech.button.activate": "Activar",
+  "gui.biometech.button.deactivate": "Desactivar",
+  "gui.biometech.no_biome": "Ningún Bioma Seleccionado!",
+  "gui.biometech.radius": "Radio: %s",
+  "gui.biometech.button.clear_biome": "Clic para quitar el bioma!",
+  "gamerule.biometech:fuel_per_change": "Cantidad de combustible para un solo cambio de bioma",
+  "gamerule.biometech:uses_per_essence": "Cantidad de usos de una sola Esencia de Bioma",
+  "gamerule.biometech:delay_between_changes": "Retraso (en ticks) entre cambios de bioma",
+  "gamerule.biometech:max_checks_per_tick": "Número máximo de chequeos de bioma por tick",
+  "gamerule.biometech:max_radius": "Radio máximo del Convertidor de Bioma",
+  "gamerule.biometech:wandering_traders_sell_essence": "Comerciantes Nómadas venden Esencia de Bioma"
+}


### PR DESCRIPTION
Included lang files for all the spanish-speaking countries:

- es_ar.json - Argentina
- es_cl.json - Chile
- es_ec.json - Ecuador
- es_es.json - Spain
- es_mx.json - Mexico
- es_uy.json - Uruguay
- es_ve.json - Venezuela

Note: the "Wandering Trader" is translated differently in some countries so I checked the official language files of each country and translated it accordingly.